### PR TITLE
BUG: zoom with negative factor never gets damped

### DIFF
--- a/examples/js/controls/TrackballControls.js
+++ b/examples/js/controls/TrackballControls.js
@@ -218,16 +218,16 @@ THREE.TrackballControls = function ( object, domElement ) {
 			if ( factor !== 1.0 && factor > 0.0 ) {
 
 				_eye.multiplyScalar( factor );
+				
+			}
 
-				if ( _this.staticMoving ) {
+			if ( _this.staticMoving ) {
 
-					_zoomStart.copy( _zoomEnd );
+				_zoomStart.copy( _zoomEnd );
 
-				} else {
+			} else {
 
-					_zoomStart.y += ( _zoomEnd.y - _zoomStart.y ) * this.dynamicDampingFactor;
-
-				}
+				_zoomStart.y += ( _zoomEnd.y - _zoomStart.y ) * this.dynamicDampingFactor;
 
 			}
 


### PR DESCRIPTION
When using a mouse wheel to zoom in and out quickly, sometimes zoomCamera's factor can go negative. When that happens, _zoomStart.y never gets reset to 0, causing zooming to stop. The fix is to always update _zoomStart, but only update _eye when (factor != 1.0 && zoom > 0.0) .
